### PR TITLE
Add secondary mirror to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ A game of truly quantum chess, with interference, entanglement, etc.
 
 You can play online in your browser on https://truly-quantum-chess.sloppy.zone.
 
+There is also a mirror of the game on https://quantum-chess.mateowang.dev if the above link is down.
+
 Alternatively, download, build & run your local mongodb and webapp server. To do so simply run:
 ```
 docker-compose build


### PR DESCRIPTION
I've noticed that the game hosted at sloppy.zone has been going down recently. I'm offering to host it on my servers for free to anyone who wants to play it. I'll do my best to keep it up for the foreseeable future.

I hope linking it on the README.md will increase visibility so more players can access the game if the sloppy.zone server is ever down. :)

Additionally, games on my server are cached for 24 hours instead of 2, so as long as your last move was within the last day, the game will not be cleared.